### PR TITLE
update guava dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/791a8e6d43634307a1649ca6f5ad7a2e)](https://www.codacy.com/app/anton-rib/atsd-jdbc)
 [![License](https://img.shields.io/badge/License-Apache%202-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.axibase/atsd-jdbc/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.axibase/atsd-jdbc)
-[![Dependency Status](https://www.versioneye.com/user/projects/57b45de0f0b3bb0049ff712b/badge.svg?style=flat-square)](https://www.versioneye.com/user/projects/57b45de0f0b3bb0049ff712b)
 [![Known Vulnerabilities](https://snyk.io/test/github/axibase/atsd-jdbc/badge.svg?targetFile=pom.xml)](https://snyk.io/test/github/axibase/atsd-jdbc?targetFile=pom.xml)
 
 # JDBC driver

--- a/pom.xml
+++ b/pom.xml
@@ -405,7 +405,8 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>20.0</version>
+			<version>25.1-android</version>
+			<!--android version is used for Java 7 support-->
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>

--- a/src/main/java/com/axibase/tsd/driver/jdbc/DriverConstants.java
+++ b/src/main/java/com/axibase/tsd/driver/jdbc/DriverConstants.java
@@ -71,7 +71,7 @@ public final class DriverConstants {
 	public static final String COMPRESSION_ENCODING = "gzip";
 	public static final String DEFAULT_ENCODING = "identity";
 	public static final String FORM_URLENCODED_TYPE = "application/x-www-form-urlencoded";
-	public static final String USER_AGENT = "ATSD Client/1.0 axibase.com";
+	public static final String USER_AGENT = "ATSD JDBC Client/" + JDBC_DRIVER_VERSION_DEFAULT;
 
 	public static final String DEFAULT_TABLE_NAME = "atsd_series";
 	public static final String TEXT_TITLES = "text";

--- a/src/main/java/com/axibase/tsd/driver/jdbc/content/ContentMetadata.java
+++ b/src/main/java/com/axibase/tsd/driver/jdbc/content/ContentMetadata.java
@@ -114,7 +114,7 @@ public class ContentMetadata {
 		final String table = (String) property.get(TABLE_PROPERTY);
 		final String datatype = property.get(DATATYPE_PROPERTY).toString(); // may be represented as a json object (hashmap)
 		final String propertyUrl = (String) property.get(PROPERTY_URL);
-		final AtsdType atsdType = EnumUtil.getAtsdTypeByOriginalName(datatype);
+		final AtsdType atsdType = EnumUtil.getAtsdTypeByOriginalName(datatype, name);
 		final boolean nullable = atsdType == AtsdType.JAVA_OBJECT_TYPE || (atsdType == AtsdType.STRING_DATA_TYPE
 				&& (StringUtils.endsWithIgnoreCase(propertyUrl, "Tag") || TEXT_TITLES.equals(title)));
 		return new ColumnMetaDataBuilder(assignColumnNames, odbcCompatible)

--- a/src/main/java/com/axibase/tsd/driver/jdbc/content/DataProvider.java
+++ b/src/main/java/com/axibase/tsd/driver/jdbc/content/DataProvider.java
@@ -49,7 +49,7 @@ public class DataProvider implements IDataProvider {
 		switch (statementType) {
 			case SELECT: {
 				if (context.isEncodeTags()) {
-					endpoint = Location.SQL_ENDPOINT.getUrl(connectionInfo) + "?encodeTags=true";
+					endpoint = Location.SQL_ENDPOINT.getUrl(connectionInfo) + "&encodeTags=true";
 				} else {
 					endpoint = Location.SQL_ENDPOINT.getUrl(connectionInfo);
 				}

--- a/src/main/java/com/axibase/tsd/driver/jdbc/enums/AtsdType.java
+++ b/src/main/java/com/axibase/tsd/driver/jdbc/enums/AtsdType.java
@@ -122,6 +122,9 @@ public enum AtsdType {
 				return null;
 			}
 			try {
+				if (cell.charAt(cell.length() - 1) != 'Z') { // datetime is not in ISO format, hence datetimeAsNumber option used
+					return new Timestamp(Long.parseLong(cell));
+				}
 				final long millis = IsoDateParseUtil.parseIso8601(cell);
 				return new Timestamp(millis);
 			} catch (Exception e) {

--- a/src/main/java/com/axibase/tsd/driver/jdbc/enums/Location.java
+++ b/src/main/java/com/axibase/tsd/driver/jdbc/enums/Location.java
@@ -4,7 +4,7 @@ import com.axibase.tsd.driver.jdbc.ext.AtsdConnectionInfo;
 import lombok.Getter;
 
 public enum Location {
-	SQL_ENDPOINT("/api/sql"),
+	SQL_ENDPOINT("/api/sql?datetimeAsNumber=true"),
 	SQL_META_ENDPOINT("/api/sql/meta"),
 	CANCEL_ENDPOINT("/api/sql/cancel"),
 	METRICS_ENDPOINT("/api/v1/metrics"),

--- a/src/main/java/com/axibase/tsd/driver/jdbc/ext/AtsdMeta.java
+++ b/src/main/java/com/axibase/tsd/driver/jdbc/ext/AtsdMeta.java
@@ -614,7 +614,7 @@ public class AtsdMeta extends MetaImpl {
 				final Map<String, AtsdType> result = new LinkedHashMap<>();
 				for (Metric metric : metrics) {
 					if (WildcardsUtil.wildcardMatch(metric.getName(), pattern)) {
-						result.put(metric.getName(), EnumUtil.getAtsdTypeByOriginalName(metric.getDataType()));
+						result.put(metric.getName(), EnumUtil.getAtsdTypeByOriginalName(metric.getDataType(), metric.getName()));
 					}
 				}
 				return result;

--- a/src/main/java/com/axibase/tsd/driver/jdbc/strategies/Consumer.java
+++ b/src/main/java/com/axibase/tsd/driver/jdbc/strategies/Consumer.java
@@ -64,7 +64,7 @@ public class Consumer implements IConsumer {
 
 	@Override
 	public String[] open(InputStream inputStream, List<ColumnMetaData> columnMetadataList) throws IOException {
-		iterator = RowIterator.newDefaultIterator(inputStream, columnMetadataList, context.isEncodeTags());
+		iterator = RowIterator.newDefaultIterator(inputStream, columnMetadataList);
 		return iterator.getHeader();
 	}
 

--- a/src/main/java/com/axibase/tsd/driver/jdbc/strategies/RowIterator.java
+++ b/src/main/java/com/axibase/tsd/driver/jdbc/strategies/RowIterator.java
@@ -86,7 +86,7 @@ public class RowIterator implements Iterator<Object[]>, AutoCloseable {
 		}
 	}
 
-	public static RowIterator newDefaultIterator(InputStream inputStream, List<ColumnMetaData> metadata, boolean encodeTags) throws IOException {
+	public static RowIterator newDefaultIterator(InputStream inputStream, List<ColumnMetaData> metadata) throws IOException {
 		Reader reader = new InputStreamReader(inputStream, DEFAULT_CHARSET);
 		return newDefaultIterator(reader, metadata);
 	}

--- a/src/main/java/com/axibase/tsd/driver/jdbc/util/EnumUtil.java
+++ b/src/main/java/com/axibase/tsd/driver/jdbc/util/EnumUtil.java
@@ -57,8 +57,11 @@ public class EnumUtil {
 		return isTokenInSet(token, reservedWordsSql2003);
 	}
 
-	public static AtsdType getAtsdTypeByOriginalName(String name) {
-		AtsdType result = atsdNameTypeMapping.get(name);
+	public static AtsdType getAtsdTypeByOriginalName(String serverTypeName, String columnName) {
+		if ("datetime".equals(columnName)) {
+			return AtsdType.TIMESTAMP_DATA_TYPE; // ATSD may return bigint for datetime column to eliminate parsing operation.
+		}
+		AtsdType result = atsdNameTypeMapping.get(serverTypeName);
 		if (result == null) {
 			result = AtsdType.DEFAULT_TYPE;
 		}


### PR DESCRIPTION
Bump guava version. It's mostly used in calcite. JDBC tests pass, so no API incompatibilities should be met after transition.